### PR TITLE
 Fix: fix for the data parse mistake due to the misalignment of the s…

### DIFF
--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "raydium_amm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arrayref",
  "arrform",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "raydium_amm"
-version = "0.3.0"
+version = "0.3.1"
 description = "Raydium AMM"
 authors = ["Raydium Maintainers "]
 repository = "https://github.com/raydium-io/raydium-amm"
@@ -14,15 +14,19 @@ no-entrypoint = ["serum_dex/no-entrypoint"]
 program = ["serum_dex/program", "serum_dex/no-entrypoint"]
 default = ["program"]
 client = ["serum_dex/client"]
-test = []
 devnet = []
-localnet = []
+testnet = []
 
 [dependencies]
 solana-program = "<1.17.0"
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
-spl-associated-token-account = { version = "2.2.0", features = ["no-entrypoint"]}
-serum_dex = { version = "0.5.10", git = "https://github.com/raydium-io/openbook-dex", features=["no-entrypoint", "program"] }
+spl-associated-token-account = { version = "2.2.0", features = [
+    "no-entrypoint",
+] }
+serum_dex = { version = "0.5.10", git = "https://github.com/raydium-io/openbook-dex", features = [
+    "no-entrypoint",
+    "program",
+] }
 serde_json = { version = "1.0.56" }
 serde = { version = "1.0", features = ["derive"] }
 bincode = { version = "1.3.3" }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -57,19 +57,19 @@ pub mod msrm_token {
     solana_program::declare_id!("MSRMcoVyrFxnSgo5uXwone5SKcGhT1KEJMFEkMEWf9L");
 }
 
-#[cfg(feature = "localnet")]
+#[cfg(feature = "testnet")]
 pub mod config_feature {
     pub mod amm_owner {
         solana_program::declare_id!("75KWb5XcqPTgacQyNw9P5QU2HL3xpezEVcgsFCiJgTT");
     }
     pub mod openbook_program {
-        solana_program::declare_id!("kGeitTdTHT1WdpUScdm8yxUAirZwbnQtqrpzvAm1p98");
+        solana_program::declare_id!("6ccSma8mmmmQXcSFpheSKrTnwsCe5pBuEpzDLFjrAsCF");
     }
     pub mod referrer_pc_wallet {
         solana_program::declare_id!("75KWb5XcqPTgacQyNw9P5QU2HL3xpezEVcgsFCiJgTT");
     }
     pub mod create_pool_fee_address {
-        solana_program::declare_id!("75KWb5XcqPTgacQyNw9P5QU2HL3xpezEVcgsFCiJgTT");
+        solana_program::declare_id!("3TRTX4dXUpp2eqxi3tvQDFYUV7SdDJjcPE3Y4mbtftaX");
     }
 }
 #[cfg(feature = "devnet")]
@@ -87,7 +87,7 @@ pub mod config_feature {
         solana_program::declare_id!("3XMrhbv989VxAMi3DErLV9eJht1pHppW5LbKxe9fkEFR");
     }
 }
-#[cfg(not(any(feature = "localnet", feature = "devnet")))]
+#[cfg(not(any(feature = "testnet", feature = "devnet")))]
 pub mod config_feature {
     pub mod amm_owner {
         solana_program::declare_id!("GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ");
@@ -450,8 +450,8 @@ impl Processor {
                 "calc_take_pnl error x:{}, y:{}, calc_pnl_x:{}, calc_pnl_y:{}",
                 x1,
                 y1,
-                target.calc_pnl_x,
-                target.calc_pnl_y
+                identity(target.calc_pnl_x),
+                identity(target.calc_pnl_y)
             )
             .as_str());
             return Err(AmmError::CalcPnlError.into());
@@ -1662,7 +1662,7 @@ impl Processor {
         }
         // withdrawpnl in all status except Uninitialized
         if amm.status == AmmStatus::Uninitialized.into_u64() {
-            msg!(&format!("withdrawpnl: status {}", amm.status));
+            msg!(&format!("withdrawpnl: status {}", identity(amm.status)));
             return Err(AmmError::InvalidStatus.into());
         }
         check_assert_eq!(
@@ -1733,8 +1733,8 @@ impl Processor {
         msg!(arrform!(
             LOG_SIZE,
             "withdrawpnl need_take_coin:{}, need_take_pc:{}",
-            amm.state_data.need_take_pnl_coin,
-            amm.state_data.need_take_pnl_pc
+            identity(amm.state_data.need_take_pnl_coin),
+            identity(amm.state_data.need_take_pnl_pc)
         )
         .as_str());
 
@@ -1777,7 +1777,7 @@ impl Processor {
             x1.as_u128().into(),
             y1.as_u128().into(),
         )?;
-        msg!(arrform!(LOG_SIZE, "withdrawpnl total_pc:{}, total_pc:{}, delta_x:{}, delta_y:{}, need_take_coin:{}, need_take_pc:{}",total_pc_without_take_pnl, total_coin_without_take_pnl, delta_x, delta_y, amm.state_data.need_take_pnl_coin, amm.state_data.need_take_pnl_pc).as_str());
+        msg!(arrform!(LOG_SIZE, "withdrawpnl total_pc:{}, total_pc:{}, delta_x:{}, delta_y:{}, need_take_coin:{}, need_take_pc:{}",total_pc_without_take_pnl, total_coin_without_take_pnl, delta_x, delta_y, identity(amm.state_data.need_take_pnl_coin), identity(amm.state_data.need_take_pnl_pc)).as_str());
 
         if amm.state_data.need_take_pnl_coin <= amm_coin_vault.amount
             && amm.state_data.need_take_pnl_pc <= amm_pc_vault.amount
@@ -2327,7 +2327,7 @@ impl Processor {
             Self::unpack_token_account(&user_destination_info, spl_token_program_id)?;
 
         if !AmmStatus::from_u64(amm.status).swap_permission() {
-            msg!(&format!("swap_base_in: status {}", amm.status));
+            msg!(&format!("swap_base_in: status {}", identity(amm.status)));
             let clock = Clock::get()?;
             if amm.status == AmmStatus::OrderBookOnly.into_u64()
                 && (clock.unix_timestamp as u64) >= amm.state_data.orderbook_to_init_time
@@ -2741,7 +2741,7 @@ impl Processor {
             Self::unpack_token_account(&user_destination_info, spl_token_program_id)?;
 
         if !AmmStatus::from_u64(amm.status).swap_permission() {
-            msg!(&format!("swap_base_out: status {}", amm.status));
+            msg!(&format!("swap_base_out: status {}", identity(amm.status)));
             let clock = Clock::get()?;
             if amm.status == AmmStatus::OrderBookOnly.into_u64()
                 && (clock.unix_timestamp as u64) >= amm.state_data.orderbook_to_init_time
@@ -3341,7 +3341,7 @@ impl Processor {
         msg!("withdraw_srm: {}", withdrawsrm.amount);
         let amm = AmmInfo::load_checked(&amm_info, program_id)?;
         if amm.status == AmmStatus::Uninitialized.into_u64() {
-            msg!(&format!("withdraw_srm: status {}", amm.status));
+            msg!(&format!("withdraw_srm: status {}", identity(amm.status)));
             return Err(AmmError::InvalidStatus.into());
         }
         if !amm_owner_info.is_signer || *amm_owner_info.key != config_feature::amm_owner::ID {
@@ -3578,7 +3578,7 @@ impl Processor {
             let amm = AmmInfo::load_checked(&amm_info, program_id)?;
 
             if !AmmStatus::from_u64(amm.status).swap_permission() {
-                msg!("simulate_swap_base_in: status {}", amm.status);
+                msg!("simulate_swap_base_in: status {}", identity(amm.status));
                 return Err(AmmError::InvalidStatus.into());
             }
             let authority = Self::authority_id(program_id, AUTHORITY_AMM, amm.nonce as u8)?;
@@ -3800,7 +3800,7 @@ impl Processor {
             }
             let amm = AmmInfo::load_checked(&amm_info, program_id)?;
             if !AmmStatus::from_u64(amm.status).swap_permission() {
-                msg!("simulate_swap_base_out: status {}", amm.status);
+                msg!("simulate_swap_base_out: status {}", identity(amm.status));
                 return Err(AmmError::InvalidStatus.into());
             }
             let authority = Self::authority_id(program_id, AUTHORITY_AMM, amm.nonce as u8)?;
@@ -4086,7 +4086,7 @@ impl Processor {
                             Self::get_amm_orders(&open_orders, bids_orders, asks_orders)?;
                         let native_pc_total = open_orders.native_pc_total;
                         let native_coin_total = open_orders.native_coin_total;
-                        msg!(&format!("simulate_run_crank pc_amount:{}, native_pc_total:{}, coin_amount:{}, native_coin_total:{}, need_take_pnl_pc:{}, need_take_pnl_coin:{}", amm_pc_vault.amount, native_pc_total, amm_coin_vault.amount, native_coin_total, amm.state_data.need_take_pnl_pc, amm.state_data.need_take_pnl_coin));
+                        msg!(&format!("simulate_run_crank pc_amount:{}, native_pc_total:{}, coin_amount:{}, native_coin_total:{}, need_take_pnl_pc:{}, need_take_pnl_coin:{}", amm_pc_vault.amount, native_pc_total, amm_coin_vault.amount, native_coin_total, identity(amm.state_data.need_take_pnl_pc), identity(amm.state_data.need_take_pnl_coin)));
                         let (total_pc_without_take_pnl, total_coin_without_take_pnl) =
                             Calculator::calc_total_without_take_pnl(
                                 amm_pc_vault.amount,
@@ -4109,7 +4109,10 @@ impl Processor {
                         );
                         msg!(&format!(
                             "simulate_run_crank x:{}, y:{}, place_x:{}, place_y:{}",
-                            x, y, target.placed_x, target.placed_y
+                            x,
+                            y,
+                            identity(target.placed_x),
+                            identity(target.placed_y)
                         ));
                         if x.is_zero() || y.is_zero() {
                             run_crank_data.run_crank = false;
@@ -4139,8 +4142,8 @@ impl Processor {
                                 "{}, {}, {}, {}",
                                 x,
                                 y,
-                                target.calc_pnl_x,
-                                target.calc_pnl_y
+                                identity(target.calc_pnl_x),
+                                identity(target.calc_pnl_y)
                             )
                             .as_str());
                             run_crank_data.run_crank = false;
@@ -4232,8 +4235,8 @@ impl Processor {
                                 "{}, {}, {}, {}",
                                 x,
                                 y,
-                                target.calc_pnl_x,
-                                target.calc_pnl_y
+                                identity(target.calc_pnl_x),
+                                identity(target.calc_pnl_y)
                             )
                             .as_str());
                             run_crank_data.run_crank = false;
@@ -4375,7 +4378,7 @@ impl Processor {
             }
         }
 
-        msg!("do_idle to_state {}", amm.state);
+        msg!("do_idle to_state {}", identity(amm.state));
         Ok(())
     }
 
@@ -4426,7 +4429,7 @@ impl Processor {
             }
             if x != target.target_x.into() || y != target.target_y.into() {
                 amm.state = AmmState::IdleState.into_u64();
-                msg!("do_plan: to_state {}", amm.state);
+                msg!("do_plan: to_state {}", identity(amm.state));
                 return Ok(());
             }
             let min_size: u64 = amm.min_size as u64;
@@ -4762,8 +4765,8 @@ impl Processor {
             .into_iter()
             .map(|item| item.client_order_id())
             .collect();
-        bids_client_ids.retain(|x| !target.replace_buy_client_id.contains(&x));
-        asks_client_ids.retain(|x| !target.replace_sell_client_id.contains(&x));
+        bids_client_ids.retain(|x| !identity(target.replace_buy_client_id).contains(&x));
+        asks_client_ids.retain(|x| !identity(target.replace_sell_client_id).contains(&x));
 
         let mut pc_avaliable = pc_vault_amount
             .checked_add(open_orders.native_pc_free)
@@ -5057,7 +5060,7 @@ impl Processor {
                 )?;
             }
         }
-        msg!("do_purge to_state {}", amm.state);
+        msg!("do_purge to_state {}", identity(amm.state));
         Ok(())
     }
 
@@ -5096,7 +5099,7 @@ impl Processor {
         if open_orders.free_slot_bits.count_zeros() > 100 && bids.is_empty() && asks.is_empty() {
             msg!(
                 "do_cancel_all to state :{}, count_zeros:{}",
-                amm.state,
+                identity(amm.state),
                 open_orders.free_slot_bits.count_zeros()
             );
             return Ok(());
@@ -5539,8 +5542,8 @@ impl Processor {
             msg!(arrform!(
                 LOG_SIZE,
                 "monitor_step Status:{}, order_num:{}",
-                amm.status,
-                amm.order_num
+                identity(amm.status),
+                identity(amm.order_num)
             )
             .as_str());
         } else {
@@ -5551,12 +5554,12 @@ impl Processor {
                 | AmmStatus::LiquidityOnly
                 | AmmStatus::SwapOnly
                 | AmmStatus::WaitingTrade => {
-                    msg!("monitor_step: AmmStatus:{}", amm.status);
+                    msg!("monitor_step: AmmStatus:{}", identity(amm.status));
                     return Err(AmmError::InvalidStatus.into());
                 }
                 AmmStatus::Initialized | AmmStatus::OrderBookOnly => match amm_state {
                     AmmState::IdleState => {
-                        msg!("monitor_step IdleState:{}", amm.state);
+                        msg!("monitor_step IdleState:{}", identity(amm.state));
                         let idle_accounts: &[AccountInfo] = &[
                             amm_info.clone(),
                             market_program_info.clone(),
@@ -5580,7 +5583,7 @@ impl Processor {
                         .unwrap();
                     }
                     AmmState::CancelAllOrdersState => {
-                        msg!("monitor_step CancelAllOrdersState:{}", amm.state);
+                        msg!("monitor_step CancelAllOrdersState:{}", identity(amm.state));
                         let cancel_all_orders_accounts: &[AccountInfo] = &[
                             amm_info.clone(),
                             market_program_info.clone(),
@@ -5609,7 +5612,7 @@ impl Processor {
                         .unwrap();
                     }
                     AmmState::PlanOrdersState => {
-                        msg!("monitor_step PlanOrdersState:{}", amm.state);
+                        msg!("monitor_step PlanOrdersState:{}", identity(amm.state));
                         let plan_buy_accounts: &[AccountInfo] = &[
                             amm_info.clone(),
                             market_info.clone(),
@@ -5631,7 +5634,7 @@ impl Processor {
                         .unwrap();
                     }
                     AmmState::CancelOrderState => {
-                        msg!("monitor_step CancelOrderState:{}", amm.state);
+                        msg!("monitor_step CancelOrderState:{}", identity(amm.state));
                         let cancel_order_accounts: &[AccountInfo] = &[
                             amm_info.clone(),
                             market_program_info.clone(),
@@ -5656,7 +5659,7 @@ impl Processor {
                         .unwrap();
                     }
                     AmmState::PlaceOrdersState => {
-                        msg!("monitor_step PlaceOrdersState:{}", amm.state);
+                        msg!("monitor_step PlaceOrdersState:{}", identity(amm.state));
                         let place_order_accounts: &[AccountInfo] = &[
                             amm_info.clone(),
                             amm_authority_info.clone(),
@@ -5688,7 +5691,7 @@ impl Processor {
                         .unwrap();
                     }
                     AmmState::PurgeOrderState => {
-                        msg!("monitor_step PurgeOrderState:{}", amm.state);
+                        msg!("monitor_step PurgeOrderState:{}", identity(amm.state));
                         let purge_orders_accounts: &[AccountInfo] = &[
                             amm_info.clone(),
                             market_program_info.clone(),
@@ -5711,7 +5714,7 @@ impl Processor {
                         .unwrap();
                     }
                     _ => {
-                        msg!("monitor_step InvalidState:{}", amm.state);
+                        msg!("monitor_step InvalidState:{}", identity(amm.state));
                     }
                 },
             }
@@ -6620,7 +6623,7 @@ mod test {
         target.calc_pnl_y = y.as_u128();
         println!(
              "init_pc_amount:{}, init_coin_amount:{}, liquidity:{}, sys_decimal_value:{}, calc_pnl_x:{}, calc_pnl_y:{}",
-             init_pc_amount, init_coin_amount, liquidity, amm.sys_decimal_value, target.calc_pnl_x, target.calc_pnl_y
+             init_pc_amount, init_coin_amount, liquidity, identity(amm.sys_decimal_value), identity(target.calc_pnl_x), identity(target.calc_pnl_y)
          );
 
         // withdraw
@@ -6689,7 +6692,7 @@ mod test {
             .unwrap();
         println!(
              "withdraw calc_pnl_x:{}, calc_pnl_y:{}, total_pc_without_take_pnl:{}, total_coin_without_take_pnl:{}",
-             target.calc_pnl_x, target.calc_pnl_y, total_pc_without_take_pnl, total_coin_without_take_pnl
+             identity(target.calc_pnl_x), identity(target.calc_pnl_y), total_pc_without_take_pnl, total_coin_without_take_pnl
          );
 
         // withdraw 2

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -4,11 +4,9 @@ use crate::{error::AmmError, math::Calculator};
 use serum_dex::state::ToAlignedBytes;
 use solana_program::{
     account_info::AccountInfo,
-    clock::Clock,
     program_error::ProgramError,
     program_pack::{IsInitialized, Pack, Sealed},
     pubkey::Pubkey,
-    sysvar::Sysvar,
 };
 
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
@@ -24,6 +22,22 @@ use std::{
 
 pub const TEN_THOUSAND: u64 = 10000;
 pub const MAX_ORDER_LIMIT: usize = 10;
+
+#[cfg(not(test))]
+pub fn get_recent_epoch() -> Result<u64, ProgramError> {
+    use solana_program::{clock::Clock, sysvar::Sysvar};
+    Ok(Clock::get()?.epoch)
+}
+
+#[cfg(test)]
+pub fn get_recent_epoch() -> Result<u64, ProgramError> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        / (2 * 24 * 3600))
+}
 
 pub trait Loadable: Pod {
     fn load_mut<'a>(account: &'a AccountInfo) -> Result<RefMut<'a, Self>, ProgramError> {
@@ -52,7 +66,7 @@ macro_rules! impl_loadable {
     };
 }
 #[cfg_attr(feature = "client", derive(Debug))]
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 pub struct TargetOrder {
     pub price: u64,
@@ -66,7 +80,7 @@ unsafe impl Pod for TargetOrder {}
 unsafe impl TriviallyTransmutable for TargetOrder {}
 
 #[cfg_attr(feature = "client", derive(Debug))]
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Clone, Copy)]
 pub struct TargetOrders {
     pub owner: [u64; 4],
@@ -456,7 +470,7 @@ fn validate_fraction(numerator: u64, denominator: u64) -> Result<(), AmmError> {
     }
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Fees {
     /// numerator of the min_separate
@@ -566,7 +580,7 @@ impl Pack for Fees {
     }
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct StateData {
     /// delay to take pnl coin
@@ -620,7 +634,7 @@ impl StateData {
 }
 
 #[cfg_attr(feature = "client", derive(Debug))]
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default, PartialEq)]
 pub struct AmmInfo {
     /// Initialized status.
@@ -825,7 +839,7 @@ impl AmmInfo {
         self.max_price_multiplier = 1000000000;
         self.client_order_id = 0;
         self.padding1 = Zeroable::zeroed();
-        self.recent_epoch = Clock::get().unwrap().epoch;
+        self.recent_epoch = get_recent_epoch().unwrap();
         self.padding2 = Zeroable::zeroed();
 
         Ok(())
@@ -841,7 +855,7 @@ impl AmmInfo {
 }
 
 /// State of amm config account
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct AmmConfig {
     /// withdraw pnl owner
@@ -998,5 +1012,532 @@ impl GetSwapBaseOutData {
     }
     pub fn from_json(data: &str) -> Self {
         serde_json::from_str(data).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_amm_info_layout() {
+        let status: u64 = 0x123456789abcdef0;
+        let nonce: u64 = 0x123456789abcde0f;
+        let order_num: u64 = 0x123456789abcd0ef;
+        let depth: u64 = 0x123456789abc0def;
+        let coin_decimals: u64 = 0x123456789ab0cdef;
+        let pc_decimals: u64 = 0x123456789a0bcdef;
+        let state: u64 = 0x1234567890abcdef;
+        let reset_flag: u64 = 0x1234567809abcdef;
+        let min_size: u64 = 0x1234567089abcdef;
+        let vol_max_cut_ratio: u64 = 0x1234560789abcdef;
+        let amount_wave: u64 = 0x1234506789abcdef;
+        let coin_lot_size: u64 = 0x1234056789abcdef;
+        let pc_lot_size: u64 = 0x1230456789abcdef;
+        let min_price_multiplier: u64 = 0x1203456789abcdef;
+        let max_price_multiplier: u64 = 0x1023456789abcdef;
+        let sys_decimal_value: u64 = 0x123456789abcdfe0;
+
+        let min_separate_numerator: u64 = 0x123456789abcfde0;
+        let min_separate_denominator: u64 = 0x123456789abfcde0;
+        let trade_fee_numerator: u64 = 0x123456789afbcde0;
+        let trade_fee_denominator: u64 = 0x123456789fabcde0;
+        let pnl_numerator: u64 = 0x12345678f9abcde0;
+        let pnl_denominator: u64 = 0x1234567f89abcde0;
+        let swap_fee_numerator: u64 = 0x123456f789abcde0;
+        let swap_fee_denominator: u64 = 0x12345f6789abcde0;
+
+        let need_take_pnl_coin: u64 = 0x1234f56789abcde0;
+        let need_take_pnl_pc: u64 = 0x123f456789abcde0;
+        let total_pnl_pc: u64 = 0x12f3456789abcde0;
+        let total_pnl_coin: u64 = 0x1f23456789abcde0;
+        let pool_open_time: u64 = 0x123456789abcedf0;
+        let padding: [u64; 2] = [0x123456789abecdf0, 0x123456789aebcdf0];
+        let orderbook_to_init_time: u64 = 0x123456789eabcdf0;
+        let swap_coin_in_amount: u128 = 0x11002233445566778899aabbccddeeff;
+        let swap_pc_out_amount: u128 = 0x11220033445566778899aabbccddeeff;
+        let swap_acc_pc_fee: u64 = 0x12345678e9abcdf0;
+        let swap_pc_in_amount: u128 = 0x11223300445566778899aabbccddeeff;
+        let swap_coin_out_amount: u128 = 0x11223344005566778899aabbccddeeff;
+        let swap_acc_coin_fee: u64 = 0x1234567e89abcdf0;
+
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        let coin_vault_mint = Pubkey::new_unique();
+        let pc_vault_mint = Pubkey::new_unique();
+        let lp_mint = Pubkey::new_unique();
+        let open_orders = Pubkey::new_unique();
+        let market = Pubkey::new_unique();
+        let market_program = Pubkey::new_unique();
+        let target_orders = Pubkey::new_unique();
+
+        let mut padding1: [u64; 8] = [0u64; 8];
+        let mut padding1_data = [0u8; 8 * 8];
+        let mut offset = 0;
+        for i in 0..8 {
+            padding1[i] = u64::MAX - i as u64;
+            padding1_data[offset..offset + 8].copy_from_slice(&padding1[i].to_le_bytes());
+            offset += 8;
+        }
+        let amm_owner = Pubkey::new_unique();
+        let lp_amount: u64 = 0x123456e789abcdf0;
+        let client_order_id: u64 = 0x12345e6789abcdf0;
+        let recent_epoch: u64 = 0x1234e56789abcdf0;
+        let padding2: u64 = 0x123e456789abcdf0;
+
+        // serialize original data
+        let mut pool_data = [0u8; 752];
+        let mut offset = 0;
+        pool_data[offset..offset + 8].copy_from_slice(&status.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&nonce.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&order_num.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&depth.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&coin_decimals.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&pc_decimals.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&state.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&reset_flag.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&min_size.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&vol_max_cut_ratio.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&amount_wave.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&coin_lot_size.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&pc_lot_size.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&min_price_multiplier.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&max_price_multiplier.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&sys_decimal_value.to_le_bytes());
+        offset += 8;
+
+        pool_data[offset..offset + 8].copy_from_slice(&min_separate_numerator.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&min_separate_denominator.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&trade_fee_numerator.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&trade_fee_denominator.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&pnl_numerator.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&pnl_denominator.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&swap_fee_numerator.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&swap_fee_denominator.to_le_bytes());
+        offset += 8;
+
+        pool_data[offset..offset + 8].copy_from_slice(&need_take_pnl_coin.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&need_take_pnl_pc.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&total_pnl_pc.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&total_pnl_coin.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&pool_open_time.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&padding[0].to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&padding[1].to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&orderbook_to_init_time.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 16].copy_from_slice(&swap_coin_in_amount.to_le_bytes());
+        offset += 16;
+        pool_data[offset..offset + 16].copy_from_slice(&swap_pc_out_amount.to_le_bytes());
+        offset += 16;
+        pool_data[offset..offset + 8].copy_from_slice(&swap_acc_pc_fee.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 16].copy_from_slice(&swap_pc_in_amount.to_le_bytes());
+        offset += 16;
+        pool_data[offset..offset + 16].copy_from_slice(&swap_coin_out_amount.to_le_bytes());
+        offset += 16;
+        pool_data[offset..offset + 8].copy_from_slice(&swap_acc_coin_fee.to_le_bytes());
+        offset += 8;
+
+        pool_data[offset..offset + 32].copy_from_slice(&coin_vault.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&pc_vault.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&coin_vault_mint.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&pc_vault_mint.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&lp_mint.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&open_orders.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&market.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&market_program.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 32].copy_from_slice(&target_orders.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 8 * 8].copy_from_slice(&padding1_data);
+        offset += 8 * 8;
+        pool_data[offset..offset + 32].copy_from_slice(&amm_owner.to_bytes());
+        offset += 32;
+        pool_data[offset..offset + 8].copy_from_slice(&lp_amount.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&client_order_id.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&recent_epoch.to_le_bytes());
+        offset += 8;
+        pool_data[offset..offset + 8].copy_from_slice(&padding2.to_le_bytes());
+        offset += 8;
+
+        // len check
+        assert_eq!(offset, pool_data.len());
+        assert_eq!(pool_data.len(), core::mem::size_of::<AmmInfo>());
+
+        // deserialize original data
+        let unpack_data: &AmmInfo =
+            bytemuck::from_bytes(&pool_data[0..core::mem::size_of::<AmmInfo>()]);
+        // data check
+        let unpack_status = unpack_data.status;
+        assert_eq!(status, unpack_status);
+        let unpack_nonce = unpack_data.nonce;
+        assert_eq!(nonce, unpack_nonce);
+        let unpack_order_num = unpack_data.order_num;
+        assert_eq!(order_num, unpack_order_num);
+        let unpack_depth = unpack_data.depth;
+        assert_eq!(depth, unpack_depth);
+        let unpack_coin_decimals = unpack_data.coin_decimals;
+        assert_eq!(coin_decimals, unpack_coin_decimals);
+        let unpack_pc_decimals = unpack_data.pc_decimals;
+        assert_eq!(pc_decimals, unpack_pc_decimals);
+        let unpack_state = unpack_data.state;
+        assert_eq!(state, unpack_state);
+        let unpack_reset_flag = unpack_data.reset_flag;
+        assert_eq!(reset_flag, unpack_reset_flag);
+        let unpack_min_size = unpack_data.min_size;
+        assert_eq!(min_size, unpack_min_size);
+        let unpack_vol_max_cut_ratio = unpack_data.vol_max_cut_ratio;
+        assert_eq!(vol_max_cut_ratio, unpack_vol_max_cut_ratio);
+        let unpack_amount_wave = unpack_data.amount_wave;
+        assert_eq!(amount_wave, unpack_amount_wave);
+        let unpack_coin_lot_size = unpack_data.coin_lot_size;
+        assert_eq!(coin_lot_size, unpack_coin_lot_size);
+        let unpack_pc_lot_size = unpack_data.pc_lot_size;
+        assert_eq!(pc_lot_size, unpack_pc_lot_size);
+        let unpack_min_price_multiplier = unpack_data.min_price_multiplier;
+        assert_eq!(min_price_multiplier, unpack_min_price_multiplier);
+        let unpack_max_price_multiplier = unpack_data.max_price_multiplier;
+        assert_eq!(max_price_multiplier, unpack_max_price_multiplier);
+        let unpack_sys_decimal_value = unpack_data.sys_decimal_value;
+        assert_eq!(sys_decimal_value, unpack_sys_decimal_value);
+        let unpack_min_separate_numerator = unpack_data.fees.min_separate_numerator;
+        assert_eq!(min_separate_numerator, unpack_min_separate_numerator);
+        let unpack_min_separate_denominator = unpack_data.fees.min_separate_denominator;
+        assert_eq!(min_separate_denominator, unpack_min_separate_denominator);
+        let unpack_trade_fee_numerator = unpack_data.fees.trade_fee_numerator;
+        assert_eq!(trade_fee_numerator, unpack_trade_fee_numerator);
+        let unpack_trade_fee_denominator = unpack_data.fees.trade_fee_denominator;
+        assert_eq!(trade_fee_denominator, unpack_trade_fee_denominator);
+        let unpack_pnl_numerator = unpack_data.fees.pnl_numerator;
+        assert_eq!(pnl_numerator, unpack_pnl_numerator);
+        let unpack_pnl_denominator = unpack_data.fees.pnl_denominator;
+        assert_eq!(pnl_denominator, unpack_pnl_denominator);
+        let unpack_swap_fee_numerator = unpack_data.fees.swap_fee_numerator;
+        assert_eq!(swap_fee_numerator, unpack_swap_fee_numerator);
+        let unpack_swap_fee_denominator = unpack_data.fees.swap_fee_denominator;
+        assert_eq!(swap_fee_denominator, unpack_swap_fee_denominator);
+        let unpack_need_take_pnl_coin = unpack_data.state_data.need_take_pnl_coin;
+        assert_eq!(need_take_pnl_coin, unpack_need_take_pnl_coin);
+        let unpack_need_take_pnl_pc = unpack_data.state_data.need_take_pnl_pc;
+        assert_eq!(need_take_pnl_pc, unpack_need_take_pnl_pc);
+        let unpack_total_pnl_pc = unpack_data.state_data.total_pnl_pc;
+        assert_eq!(total_pnl_pc, unpack_total_pnl_pc);
+        let unpack_total_pnl_coin = unpack_data.state_data.total_pnl_coin;
+        assert_eq!(total_pnl_coin, unpack_total_pnl_coin);
+        let unpack_pool_open_time = unpack_data.state_data.pool_open_time;
+        assert_eq!(pool_open_time, unpack_pool_open_time);
+        for i in 0..2 {
+            let unpack_padding = unpack_data.state_data.padding[i];
+            assert_eq!(padding[i], unpack_padding);
+        }
+        let unpack_orderbook_to_init_time = unpack_data.state_data.orderbook_to_init_time;
+        assert_eq!(orderbook_to_init_time, unpack_orderbook_to_init_time);
+        let unpack_swap_coin_in_amount = unpack_data.state_data.swap_coin_in_amount;
+        assert_eq!(swap_coin_in_amount, unpack_swap_coin_in_amount);
+        let unpack_swap_pc_out_amount = unpack_data.state_data.swap_pc_out_amount;
+        assert_eq!(swap_pc_out_amount, unpack_swap_pc_out_amount);
+        let unpack_swap_acc_pc_fee = unpack_data.state_data.swap_acc_pc_fee;
+        assert_eq!(swap_acc_pc_fee, unpack_swap_acc_pc_fee);
+        let unpack_swap_pc_in_amount = unpack_data.state_data.swap_pc_in_amount;
+        assert_eq!(swap_pc_in_amount, unpack_swap_pc_in_amount);
+        let unpack_swap_coin_out_amount = unpack_data.state_data.swap_coin_out_amount;
+        assert_eq!(swap_coin_out_amount, unpack_swap_coin_out_amount);
+        let unpack_swap_acc_coin_fee = unpack_data.state_data.swap_acc_coin_fee;
+        assert_eq!(swap_acc_coin_fee, unpack_swap_acc_coin_fee);
+        let unpack_coin_vault = unpack_data.coin_vault;
+        assert_eq!(coin_vault, unpack_coin_vault);
+        let unpack_pc_vault = unpack_data.pc_vault;
+        assert_eq!(pc_vault, unpack_pc_vault);
+        let unpack_coin_vault_mint = unpack_data.coin_vault_mint;
+        assert_eq!(coin_vault_mint, unpack_coin_vault_mint);
+        let unpack_pc_vault_mint = unpack_data.pc_vault_mint;
+        assert_eq!(pc_vault_mint, unpack_pc_vault_mint);
+        let unpack_lp_mint = unpack_data.lp_mint;
+        assert_eq!(lp_mint, unpack_lp_mint);
+        let unpack_open_orders = unpack_data.open_orders;
+        assert_eq!(open_orders, unpack_open_orders);
+        let unpack_market = unpack_data.market;
+        assert_eq!(market, unpack_market);
+        let unpack_market_program = unpack_data.market_program;
+        assert_eq!(market_program, unpack_market_program);
+        let unpack_target_orders = unpack_data.target_orders;
+        assert_eq!(target_orders, unpack_target_orders);
+        for i in 0..8 {
+            let unpack_padding1 = unpack_data.padding1[i];
+            assert_eq!(padding1[i], unpack_padding1);
+        }
+        let unpack_amm_owner = unpack_data.amm_owner;
+        assert_eq!(amm_owner, unpack_amm_owner);
+        let unpack_lp_amount = unpack_data.lp_amount;
+        assert_eq!(lp_amount, unpack_lp_amount);
+        let unpack_client_order_id = unpack_data.client_order_id;
+        assert_eq!(client_order_id, unpack_client_order_id);
+        let unpack_recent_epoch = unpack_data.recent_epoch;
+        assert_eq!(recent_epoch, unpack_recent_epoch);
+        let unpack_padding2 = unpack_data.padding2;
+        assert_eq!(padding2, unpack_padding2);
+    }
+
+    #[test]
+    fn test_target_info_layout() {
+        let owner: [u64; 4] = [
+            0x123456789abcedf0,
+            0x123456789abced0f,
+            0x123456789abce0df,
+            0x123456789abc0edf,
+        ];
+        let mut buy_orders: [TargetOrder; 50] = [TargetOrder::default(); 50];
+        let mut buy_orders_data = [0u8; 8 * 2 * 50];
+        let mut offset = 0;
+        for i in 0..50 {
+            buy_orders[i].price = u64::MAX - i as u64;
+            buy_orders[i].vol = u64::MAX - 3 * i as u64;
+            buy_orders_data[offset..offset + 8].copy_from_slice(&buy_orders[i].price.to_le_bytes());
+            offset += 8;
+            buy_orders_data[offset..offset + 8].copy_from_slice(&buy_orders[i].vol.to_le_bytes());
+            offset += 8;
+        }
+        let mut padding1 = [0u64; 8];
+        for i in 0..8 {
+            padding1[i] = 1 << i;
+        }
+        let target_x: u128 = 0x11002233445566778899aabbccddeeff;
+        let target_y: u128 = 0x11220033445566778899aabbccddeeff;
+        let plan_x_buy: u128 = 0x11223300445566778899aabbccddeeff;
+        let plan_y_buy: u128 = 0x11223344005566778899aabbccddeeff;
+        let plan_x_sell: u128 = 0x11223344550066778899aabbccddeeff;
+        let plan_y_sell: u128 = 0x11223344556600778899aabbccddeeff;
+        let placed_x: u128 = 0x11223344556677008899aabbccddeeff;
+        let placed_y: u128 = 0x11223344556677880099aabbccddeeff;
+        let calc_pnl_x: u128 = 0x11223344556677889900aabbccddeeff;
+        let calc_pnl_y: u128 = 0x112233445566778899aa00bbccddeeff;
+        let mut sell_orders: [TargetOrder; 50] = [TargetOrder::default(); 50];
+        let mut sell_orders_data = [0u8; 8 * 2 * 50];
+        let mut offset = 0;
+        for i in 0..50 {
+            sell_orders[i].price = u64::MAX - (i + 50) as u64;
+            sell_orders[i].vol = u64::MAX - 3 * (i + 50) as u64;
+            sell_orders_data[offset..offset + 8]
+                .copy_from_slice(&sell_orders[i].price.to_le_bytes());
+            offset += 8;
+            sell_orders_data[offset..offset + 8].copy_from_slice(&sell_orders[i].vol.to_le_bytes());
+            offset += 8;
+        }
+        let mut padding2 = [0u64; 6];
+        for i in 0..6 {
+            padding2[i] = 1 << (i + 8);
+        }
+        let mut replace_buy_client_id = [0u64; MAX_ORDER_LIMIT];
+        let mut replace_sell_client_id = [0u64; MAX_ORDER_LIMIT];
+        for i in 0..MAX_ORDER_LIMIT {
+            replace_buy_client_id[i] = 1 << (i + 8 + 6);
+            replace_sell_client_id[i] = 1 << (i + 8 + 6 + MAX_ORDER_LIMIT);
+        }
+        let last_order_numerator: u64 = 0x123456789ab0cedf;
+        let last_order_denominator: u64 = 0x123456789a0bcedf;
+        let plan_orders_cur: u64 = 0x1234567890abcedf;
+        let place_orders_cur: u64 = 0x1234567809abcedf;
+        let valid_buy_order_num: u64 = 0x1234567089abcedf;
+        let valid_sell_order_num: u64 = 0x1234560789abcedf;
+        let mut padding3 = [0u64; 10];
+        for i in 0..10 {
+            padding3[i] = 1 << (i + 8 + 6 + MAX_ORDER_LIMIT + MAX_ORDER_LIMIT);
+        }
+        let free_slot_bits: u128 = 0x112233445566778899aabb00ccddeeff;
+
+        // serialize original data
+        let mut target_orders_data = [0u8; 2208];
+        let mut offset = 0;
+        for i in 0..4 {
+            target_orders_data[offset..offset + 8].copy_from_slice(&owner[i].to_le_bytes());
+            offset += 8;
+        }
+        target_orders_data[offset..offset + 8 * 2 * 50].copy_from_slice(&buy_orders_data);
+        offset += 8 * 2 * 50;
+        for i in 0..8 {
+            target_orders_data[offset..offset + 8].copy_from_slice(&padding1[i].to_le_bytes());
+            offset += 8;
+        }
+        target_orders_data[offset..offset + 16].copy_from_slice(&target_x.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&target_y.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&plan_x_buy.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&plan_y_buy.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&plan_x_sell.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&plan_y_sell.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&placed_x.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&placed_y.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&calc_pnl_x.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 16].copy_from_slice(&calc_pnl_y.to_le_bytes());
+        offset += 16;
+        target_orders_data[offset..offset + 8 * 2 * 50].copy_from_slice(&sell_orders_data);
+        offset += 8 * 2 * 50;
+        for i in 0..6 {
+            target_orders_data[offset..offset + 8].copy_from_slice(&padding2[i].to_le_bytes());
+            offset += 8;
+        }
+        for i in 0..MAX_ORDER_LIMIT {
+            target_orders_data[offset..offset + 8]
+                .copy_from_slice(&replace_buy_client_id[i].to_le_bytes());
+            offset += 8;
+        }
+        for i in 0..MAX_ORDER_LIMIT {
+            target_orders_data[offset..offset + 8]
+                .copy_from_slice(&replace_sell_client_id[i].to_le_bytes());
+            offset += 8;
+        }
+        target_orders_data[offset..offset + 8].copy_from_slice(&last_order_numerator.to_le_bytes());
+        offset += 8;
+        target_orders_data[offset..offset + 8]
+            .copy_from_slice(&last_order_denominator.to_le_bytes());
+        offset += 8;
+        target_orders_data[offset..offset + 8].copy_from_slice(&plan_orders_cur.to_le_bytes());
+        offset += 8;
+        target_orders_data[offset..offset + 8].copy_from_slice(&place_orders_cur.to_le_bytes());
+        offset += 8;
+        target_orders_data[offset..offset + 8].copy_from_slice(&valid_buy_order_num.to_le_bytes());
+        offset += 8;
+        target_orders_data[offset..offset + 8].copy_from_slice(&valid_sell_order_num.to_le_bytes());
+        offset += 8;
+        for i in 0..10 {
+            target_orders_data[offset..offset + 8].copy_from_slice(&padding3[i].to_le_bytes());
+            offset += 8;
+        }
+        target_orders_data[offset..offset + 16].copy_from_slice(&free_slot_bits.to_le_bytes());
+        offset += 16;
+
+        // len check
+        assert_eq!(offset, target_orders_data.len());
+        assert_eq!(
+            target_orders_data.len(),
+            core::mem::size_of::<TargetOrders>()
+        );
+
+        // deserialize original data
+        let unpack_data: &TargetOrders =
+            bytemuck::from_bytes(&target_orders_data[0..core::mem::size_of::<TargetOrders>()]);
+        // data check
+        let unpack_owner = unpack_data.owner;
+        for i in 0..4 {
+            assert_eq!(owner[i], unpack_owner[i]);
+        }
+        let unpack_buy_orders = unpack_data.buy_orders;
+        for i in 0..50 {
+            let price = buy_orders[i].price;
+            let unpack_price = unpack_buy_orders[i].price;
+            assert_eq!(price, unpack_price);
+            let vol = buy_orders[i].vol;
+            let unpack_vol = unpack_buy_orders[i].vol;
+            assert_eq!(vol, unpack_vol);
+        }
+        let unpack_padding1 = unpack_data.padding1;
+        for i in 0..8 {
+            assert_eq!(padding1[i], unpack_padding1[i]);
+        }
+        let unpack_target_x = unpack_data.target_x;
+        assert_eq!(target_x, unpack_target_x);
+        let unpack_target_y = unpack_data.target_y;
+        assert_eq!(target_y, unpack_target_y);
+        let unpack_plan_x_buy = unpack_data.plan_x_buy;
+        assert_eq!(plan_x_buy, unpack_plan_x_buy);
+        let unpack_plan_y_buy = unpack_data.plan_y_buy;
+        assert_eq!(plan_y_buy, unpack_plan_y_buy);
+        let unpack_plan_x_sell = unpack_data.plan_x_sell;
+        assert_eq!(plan_x_sell, unpack_plan_x_sell);
+        let unpack_plan_y_sell = unpack_data.plan_y_sell;
+        assert_eq!(plan_y_sell, unpack_plan_y_sell);
+        let unpack_placed_x = unpack_data.placed_x;
+        assert_eq!(placed_x, unpack_placed_x);
+        let unpack_placed_y = unpack_data.placed_y;
+        assert_eq!(placed_y, unpack_placed_y);
+        let unpack_calc_pnl_x = unpack_data.calc_pnl_x;
+        assert_eq!(calc_pnl_x, unpack_calc_pnl_x);
+        let unpack_calc_pnl_y = unpack_data.calc_pnl_y;
+        assert_eq!(calc_pnl_y, unpack_calc_pnl_y);
+        let unpack_sell_orders = unpack_data.sell_orders;
+        for i in 0..50 {
+            let price = sell_orders[i].price;
+            let unpack_price = unpack_sell_orders[i].price;
+            assert_eq!(price, unpack_price);
+            let vol = sell_orders[i].vol;
+            let unpack_vol = unpack_sell_orders[i].vol;
+            assert_eq!(vol, unpack_vol);
+        }
+        let unpack_padding2 = unpack_data.padding2;
+        for i in 0..6 {
+            assert_eq!(padding2[i], unpack_padding2[i]);
+        }
+        let unpack_replace_buy_client_id = unpack_data.replace_buy_client_id;
+        for i in 0..MAX_ORDER_LIMIT {
+            assert_eq!(replace_buy_client_id[i], unpack_replace_buy_client_id[i]);
+        }
+        let unpack_replace_sell_client_id = unpack_data.replace_sell_client_id;
+        for i in 0..MAX_ORDER_LIMIT {
+            assert_eq!(replace_sell_client_id[i], unpack_replace_sell_client_id[i]);
+        }
+        let unpack_last_order_numerator = unpack_data.last_order_numerator;
+        assert_eq!(last_order_numerator, unpack_last_order_numerator);
+        let unpack_last_order_denominator = unpack_data.last_order_denominator;
+        assert_eq!(last_order_denominator, unpack_last_order_denominator);
+        let unpack_plan_orders_cur = unpack_data.plan_orders_cur;
+        assert_eq!(plan_orders_cur, unpack_plan_orders_cur);
+        let unpack_place_orders_cur = unpack_data.place_orders_cur;
+        assert_eq!(place_orders_cur, unpack_place_orders_cur);
+        let unpack_valid_buy_order_num = unpack_data.valid_buy_order_num;
+        assert_eq!(valid_buy_order_num, unpack_valid_buy_order_num);
+        let unpack_valid_sell_order_num = unpack_data.valid_sell_order_num;
+        assert_eq!(valid_sell_order_num, unpack_valid_sell_order_num);
+        let unpack_padding3 = unpack_data.padding3;
+        for i in 0..10 {
+            assert_eq!(padding3[i], unpack_padding3[i]);
+        }
+        let unpack_free_slot_bits = unpack_data.free_slot_bits;
+        assert_eq!(free_slot_bits, unpack_free_slot_bits);
     }
 }


### PR DESCRIPTION
Solve the parsing mistake caused by adding padding due to byte misalignment of AmmInfo, TargetOrders and AmmConfig over rust 1.81.0