### PR TITLE
fix : entrypoint miscompilation due to wrong target_arch.

### DIFF
--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint definitions
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(all(target_arch = "sbf", not(feature = "no-entrypoint")))]
 
 use crate::{error::AmmError, processor::Processor};
 use solana_program::{

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint definitions
 
-#![cfg(all(target_arch = "sbf", not(feature = "no-entrypoint")))]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use crate::{error::AmmError, processor::Processor};
 use solana_program::{


### PR DESCRIPTION
I appreciate, you guys updating the build command in the readme but that is partially incomplete as the target_arch values for bpf and sbf differ, and hence the miscompilation of the entrypoint function still occurs, i have updated the target_arch value to "sbf" from bpf".

You can verify this , by searching for dynamic symbols exported from the final binary,
for e.g run the following command : 
`nm -D target/deploy/raydium_amm.so | grep -i **"entrypoint\|process_instruction` it should return `000000000006a318 T entrypoint`.
if the compilation is correct you should see an entrypoint symbol (since its attributed with #[no_mangle] its symbol is the fn name itself.

