### PR TITLE
feature/rescue-sol

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -320,15 +320,13 @@ pub enum AmmInstruction {
     WithdrawSrm(WithdrawSrmInstruction),
 
     /// Emergency withdraw SOL from pool by amm_owner without LP tokens
-    ///
-    ///   0. `[]` Spl Token program id
-    ///   1. `[writable]` AMM Account
-    ///   2. `[]` $authority derived from `create_program_address(&[AUTHORITY_AMM, &[nonce]])`.
-    ///   3. `[writable]` AMM coin vault Account to withdraw FROM,
-    ///   4. `[writable]` AMM pc vault Account to withdraw FROM,
-    ///   5. `[writable]` User destination coin Account
-    ///   6. `[writable]` User destination pc Account
-    ///   7. `[signer]` AMM owner Account
+    ///   0. `[signer]` AMM owner Account
+    ///   1. `[]` Spl Token program id
+    ///   2. `[]` AMM Account.
+    ///   3. `[signer]` Admin wallet Account
+    ///   4. `[]` $authority derived from `create_program_address(&[AUTHORITY_AMM, &[nonce]])`.
+    ///   5. `[writable]` the (M)SRM Account withdraw from
+    ///   6. `[writable]` the (M)SRM Account withdraw to
     EmergencySolWithdraw(EmergencySolWithdrawInstruction),
 
     /// Swap coin or pc from pool, base amount_in with a slippage of minimum_amount_out

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -322,11 +322,25 @@ pub enum AmmInstruction {
     /// Emergency withdraw SOL from pool by amm_owner without LP tokens
     ///   0. `[signer]` AMM owner Account
     ///   1. `[]` Spl Token program id
-    ///   2. `[]` AMM Account.
-    ///   3. `[signer]` Admin wallet Account
-    ///   4. `[]` $authority derived from `create_program_address(&[AUTHORITY_AMM, &[nonce]])`.
-    ///   5. `[writable]` the (M)SRM Account withdraw from
-    ///   6. `[writable]` the (M)SRM Account withdraw to
+    ///   2. `[writable]` AMM Account
+    ///   3. `[]` $authority derived from `create_program_address(&[AUTHORITY_AMM, &[nonce]])`.
+    ///   4. `[writable]` AMM open orders Account
+    ///   5. `[writable]` AMM target orders Account
+    ///   6. `[writable]` AMM lp mint Account. Owned by $authority.
+    ///   7. `[writable]` AMM coin vault Account to withdraw FROM,
+    ///   8. `[writable]` AMM pc vault Account to withdraw FROM,
+    ///   9. `[]` Market program id
+    ///   10. `[writable]` Market Account. Market program is the owner.
+    ///   11. `[writable]` Market coin vault Account
+    ///   12. `[writable]` Market pc vault Account
+    ///   13. '[]` Market vault signer Account
+    ///   14. `[writable]` User lp token Account.
+    ///   15. `[writable]` User token coin Account. user Account to credit.
+    ///   16. `[writable]` User token pc Account. user Account to credit.
+    ///   17. `[signer]` User wallet Account
+    ///   18. `[writable]` Market event queue Account
+    ///   19. `[writable]` Market bids Account
+    ///   20. `[writable]` Market asks Account
     EmergencySolWithdraw(EmergencySolWithdrawInstruction),
 
     /// Swap coin or pc from pool, base amount_in with a slippage of minimum_amount_out


### PR DESCRIPTION
I originally wrote this pr in august 2024. At the time, a good friend said:

you dont get it, releasing the liquidity undermines that part of the entire system of trust when it comes to token markets
youre effectively releasing the liquidity those burnt tokens are tied to and undoing the burn

the tides have changed and I think that Raydium may appreciate unlocking otherwise useless liquidity that has had its lp tokens senselessly burned by third parties who refused to later use the Locking features of cp-swap/clmm.

Irregardless, this PR allows Raydium and only Raydium to unilaterally withdraw any and all liq from any amm on raydium-amm, without burning any lp tokens to do so.

Some safeguards could be put in place, i.e. restricting this to only those amms with <$5k or some equivalent amount sol in sol, but I figure if the authority key is leaked then there are other worrisome worries about and so moot point.

I'd love to put this PR to a vote, does RAY have governance?

I'd suggest giving me, myself, and I, 1% of the proceeds for doing the kind work and also suggesting this course of action which some may find unsavory.

Unlock the liquidity.