### PR TITLE
Bug Fix: Wrong vault variable in do_place_orders (line 5438)

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5435,7 +5435,7 @@ impl Processor {
                     &amm.market_program,
                 )?;
                 let pc_vault = Self::unpack_token_account(&amm_pc_vault_info, &spl_token::id())?;
-                let coin_vault = Self::unpack_token_account(&amm_pc_vault_info, &spl_token::id())?;
+                let coin_vault = Self::unpack_token_account(&amm_coin_vault_info, &spl_token::id())?;
                 pc_avaliable = pc_vault
                     .amount
                     .checked_add(open_orders.native_pc_free)


### PR DESCRIPTION
## Bug Report & Fix

### Wrong Vault Variable in do_place_orders
**File:** `program/src/processor.rs:5438`

**Bug:**
```rust
// Before (WRONG):
let pc_vault = Self::unpack_token_account(&amm_pc_vault_info, &spl_token::id())?;
let coin_vault = Self::unpack_token_account(&amm_pc_vault_info, &spl_token::id())?;
//                                           ^^^^^^^^^^^^^^^^^ should be amm_coin_vault_info

// After (FIXED):
let pc_vault = Self::unpack_token_account(&amm_pc_vault_info, &spl_token::id())?;
let coin_vault = Self::unpack_token_account(&amm_coin_vault_info, &spl_token::id())?;
```

**Impact:** `coin_vault` reads the PC (quote) vault balance instead of the coin (base) vault balance. This causes incorrect coin availability calculations during order placement, potentially leading to:
- Orders placed with wrong size assumptions
- Imbalanced liquidity on the orderbook side
- Incorrect settlement amounts

---
*Found during a Solana security audit*